### PR TITLE
adjusted the metrics to fit to multiclass inputs

### DIFF
--- a/brats/losses.py
+++ b/brats/losses.py
@@ -6,9 +6,10 @@ import brats.functional as F
 ONE_CLASS = 1
 
 
-class DiceLossOneClass(nn.Module):
+class DiceLoss(nn.Module):
     """
-    Compute Dice Loss for single class, calculated as 1 - dice_score.
+    Compute Dice Loss calculated as 1 - dice_score for each class and sum the
+    result..
     The loss will be averaged across batch elements.
     """
 
@@ -26,10 +27,10 @@ class DiceLossOneClass(nn.Module):
         Args:
             prediction: output of a network, expected to be already binarized.
                 Dimensions - (Batch, Channels, Depth, Height, Width)
-            target: labels.
+            target: labels. The classes (channels) should be one-hot encoded
                 Dimensions - (Batch, Channels, Depth, Height, Width)
 
         Returns:
             torch.Tensor: Computed Dice Loss
         """
-        return 1 - F.dice_one_class(prediction, target, self.epsilon)
+        return torch.sum(1 - F.dice(prediction, target, self.epsilon))

--- a/brats/metrics.py
+++ b/brats/metrics.py
@@ -9,11 +9,11 @@ ONE_CLASS = 1
 FIRST_CLASS = 0
 
 
-class DiceScoreOneClass:
+class DiceScore:
     def __init__(self, epsilon: float = 1e-6):
         """
-        Compute an average DICE score across a batch of volumes, containing only
-        prediction for one class
+        Compute an average DICE score across a batch of volumes, for each class
+        separately.
         Args:
             epsilon: Smooth factor for each element in the batch
         """
@@ -26,12 +26,13 @@ class DiceScoreOneClass:
         Args:
             prediction: Network output.
                 Dimensions - (Batch, Class, Depth, Height, Width)
-            target: Target values.
+            target: Target values. The classes should be ont-hot encoded.
                 Dimensions - (Batch, Class, Depth, Height, Width)
         Returns:
-            torch.Tensor: DICE score averaged across the whole batch
+            torch.Tensor: DICE for each class score averaged
+                across the whole batch
         """
-        return F.dice_one_class(prediction, target, self.epsilon)
+        return F.dice(prediction, target, self.epsilon)
 
 
 class RecallScore:
@@ -49,10 +50,11 @@ class RecallScore:
         Args:
             prediction: Network output.
                 Dimensions - (Batch, Class, Depth, Height, Width)
-            target: Target values.
+            target: Target values. The classes should be ont-hot encoded.
                 Dimensions - (Batch, Class, Depth, Height, Width)
         Returns:
-            torch.Tensor: Recall score averaged across the whole batch
+            torch.Tensor: Recall score for each class averaged
+                across the whole batch
         """
         return F.recall(prediction, target, self.epsilon)
 
@@ -72,10 +74,11 @@ class PrecisionScore:
         Args:
             prediction: Network output.
                 Dimensions - (Batch, Class, Depth, Height, Width)
-            target: Target values.
+            target: Target values. The classes should be ont-hot encoded.
                 Dimensions - (Batch, Class, Depth, Height, Width)
         Returns:
-            torch.Tensor: Precision score averaged across the whole batch
+            torch.Tensor: Precision score for each class averaged
+                across the whole batch
         """
         return F.precision(prediction, target, self.epsilon)
 
@@ -97,10 +100,11 @@ class FScore:
         Args:
             prediction: Network output.
                 Dimensions - (Batch, Class, Depth, Height, Width)
-            target: Target values.
+            target: Target values. The classes should be ont-hot encoded.
                 Dimensions - (Batch, Class, Depth, Height, Width)
         Returns:
-            torch.Tensor: F Score averaged across the whole batch
+            torch.Tensor: F Score for each class averaged
+                across the whole batch
         """
         return F.f_score(prediction, target, self.beta, self.epsilon)
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -13,12 +13,12 @@ class TestDice:
     def test_if_returns_1_for_perfect_fit(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
-        assert np.isclose(F.dice_one_class(images, target), 1, atol=1.e-4)
+        assert np.isclose(F.dice(images, target), 1, atol=1.e-4)
 
     def test_if_returns_0_for_worst_fit(self):
         images = torch.zeros(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
-        assert np.isclose(F.dice_one_class(images, target), 0, atol=1.e-4)
+        assert np.isclose(F.dice(images, target), 0, atol=1.e-4)
 
     @pytest.mark.parametrize("images, target, result",
                              [(torch.tensor([[0, 1, 1, 0]]),
@@ -31,15 +31,40 @@ class TestDice:
                                torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]),
                                0.6667)
                               ])
-    def test_if_returns_expected_values(self, images, target, result):
-        assert np.isclose(F.dice_one_class(images.unsqueeze(dim=CHANNEL_DIM),
-                                           target.unsqueeze(dim=CHANNEL_DIM)),
+    def test_if_returns_expected_values_for_one_class(self, images, target, result):
+        assert np.isclose(F.dice(images.unsqueeze(dim=CHANNEL_DIM),
+                                 target.unsqueeze(dim=CHANNEL_DIM)),
                            result, atol=1.e-3)
 
-    def test_if_returns_tensor_with_shape_0(self):
+    @pytest.mark.parametrize("input_shape, result", [((1, 2, 1, 1, 1), 2),
+                                                     ((2, 3, 1, 1, 1), 3),
+                                                     ((3, 3, 2, 2, 2), 3)])
+    def test_if_returns_correct_number_of_classes(self, input_shape, result):
+        images = torch.ones(*input_shape)
+        target = torch.ones(*input_shape)
+        assert len(F.dice(images, target)) == result
+
+    @pytest.mark.parametrize("images, target, classes, result",
+                             [(torch.tensor([[0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 2, 0.4),
+                              (torch.tensor([[1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 3, 0.6667),
+                              (torch.tensor([[0, 1, 1, 0], [0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 2, 0.4),
+                              (torch.tensor([[1, 1, 1, 0], [1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 4,
+                               0.6667)
+                              ])
+    def test_if_returns_expected_value_for_multiclass(self, images, target, classes, result):
+        images = images.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        target = target.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        result = [result for _ in range(classes)]
+        assert np.all(np.isclose(F.dice(images, target), result, atol=1.e-3))
+
+    def test_if_returns_tensor_with_shape_0_for_one_class(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
-        assert F.dice_one_class(images, target).shape == torch.Size([])
+        assert F.dice(images, target).shape == torch.Size([])
 
 
 class TestRecallScore:
@@ -72,7 +97,32 @@ class TestRecallScore:
                           result,
                           atol=1.e-3)
 
-    def test_if_returns_tensor_with_shape_0(self):
+    @pytest.mark.parametrize("input_shape, result", [((1, 2, 1, 1, 1), 2),
+                                                     ((2, 3, 1, 1, 1), 3),
+                                                     ((3, 3, 2, 2, 2), 3)])
+    def test_if_returns_correct_number_of_classes(self, input_shape, result):
+        images = torch.ones(*input_shape)
+        target = torch.ones(*input_shape)
+        assert len(F.recall(images, target)) == result
+
+    @pytest.mark.parametrize("images, target, classes, result",
+                             [(torch.tensor([[0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 2, 0.334),
+                              (torch.tensor([[1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 3, 0.6667),
+                              (torch.tensor([[0, 1, 1, 0], [0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 2, 0.334),
+                              (torch.tensor([[1, 1, 1, 0], [1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 4,
+                               0.6667)
+                              ])
+    def test_if_returns_expected_value_for_multiclass(self, images, target, classes, result):
+        images = images.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        target = target.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        result = [result for _ in range(classes)]
+        assert np.all(np.isclose(F.recall(images, target), result, atol=1.e-3))
+
+    def test_if_returns_tensor_with_shape_0_for_one_class(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
         assert F.recall(images, target).shape == torch.Size([])
@@ -107,14 +157,38 @@ class TestPrecisionScore:
                           result,
                           atol=1.e-3)
 
-    def test_if_returns_tensor_with_shape_0(self):
+    @pytest.mark.parametrize("input_shape, result", [((1, 2, 1, 1, 1), 2),
+                                                     ((2, 3, 1, 1, 1), 3),
+                                                     ((3, 3, 2, 2, 2), 3)])
+    def test_if_returns_correct_number_of_classes(self, input_shape, result):
+        images = torch.ones(*input_shape)
+        target = torch.ones(*input_shape)
+        assert len(F.precision(images, target)) == result
+
+    @pytest.mark.parametrize("images, target, classes, result",
+                             [(torch.tensor([[0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 2, 0.5),
+                              (torch.tensor([[1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 3, 0.6667),
+                              (torch.tensor([[0, 1, 1, 0], [0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 2, 0.5),
+                              (torch.tensor([[1, 1, 1, 0], [1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 4,
+                               0.6667)
+                              ])
+    def test_if_returns_expected_value_for_multiclass(self, images, target, classes, result):
+        images = images.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        target = target.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        result = [result for _ in range(classes)]
+        assert np.all(np.isclose(F.precision(images, target), result, atol=1.e-3))
+
+    def test_if_returns_tensor_with_shape_0_for_one_class(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
         assert F.precision(images, target).shape == torch.Size([])
 
 
 class TestFScore:
-    metric = F.f_score
 
     def test_if_returns_1_for_perfect_fit(self):
         images = torch.ones(*BATCH_DIMS)
@@ -161,7 +235,32 @@ class TestFScore:
                           result,
                           atol=1.e-3)
 
-    def test_if_returns_tensor_with_shape_0(self):
+    @pytest.mark.parametrize("input_shape, result", [((1, 2, 1, 1, 1), 2),
+                                                     ((2, 3, 1, 1, 1), 3),
+                                                     ((3, 3, 2, 2, 2), 3)])
+    def test_if_returns_correct_number_of_classes(self, input_shape, result):
+        images = torch.ones(*input_shape)
+        target = torch.ones(*input_shape)
+        assert len(F.f_score(images, target, 1)) == result
+
+    @pytest.mark.parametrize("images, target, classes, result",
+                             [(torch.tensor([[0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 2, 0.4),
+                              (torch.tensor([[1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1]]), 3, 0.6667),
+                              (torch.tensor([[0, 1, 1, 0], [0, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 2, 0.4),
+                              (torch.tensor([[1, 1, 1, 0], [1, 1, 1, 0]]),
+                               torch.tensor([[1, 1, 0, 1], [1, 1, 0, 1]]), 4,
+                               0.6667)
+                              ])
+    def test_if_returns_expected_value_for_multiclass(self, images, target, classes, result):
+        images = images.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        target = target.unsqueeze(dim=CHANNEL_DIM).repeat(1, classes, 1)
+        result = [result for _ in range(classes)]
+        assert np.all(np.isclose(F.f_score(images, target, 1), result, atol=1.e-3))
+
+    def test_if_returns_tensor_with_shape_0_for_one_class(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
         assert F.f_score(images, target, beta=1).shape == torch.Size([])

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -2,7 +2,7 @@ import torch
 import pytest
 import numpy as np
 
-from brats.losses import DiceLossOneClass
+from brats.losses import DiceLoss
 
 BATCH_DIMS = (2, 1, 5, 5, 5)
 CHANNEL_DIM = 1
@@ -12,12 +12,12 @@ class TestDiceLossOneClass:
     def test_if_returns_0_for_perfect_fit(self):
         images = torch.ones(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
-        assert np.isclose(DiceLossOneClass()(images, target), 0, atol=1.e-4)
+        assert np.isclose(DiceLoss()(images, target), 0, atol=1.e-4)
 
     def test_if_returns_1_for_worst_fit(self):
         images = torch.zeros(*BATCH_DIMS)
         target = torch.ones(*BATCH_DIMS)
-        assert np.isclose(DiceLossOneClass()(images, target), 1, atol=1.e-4)
+        assert np.isclose(DiceLoss()(images, target), 1, atol=1.e-4)
 
     @pytest.mark.parametrize("images, target, result",
                              [(torch.tensor([[0, 1, 1, 0]]),
@@ -31,7 +31,7 @@ class TestDiceLossOneClass:
                                0.334)
                               ])
     def test_if_returns_expected_values(self, images, target, result):
-        assert np.isclose(DiceLossOneClass()(images.unsqueeze(dim=CHANNEL_DIM),
-                                             target.unsqueeze(dim=CHANNEL_DIM)),
+        assert np.isclose(DiceLoss()(images.unsqueeze(dim=CHANNEL_DIM),
+                                     target.unsqueeze(dim=CHANNEL_DIM)),
                           result,
                           atol=1.e-2)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,7 +9,7 @@ CHANNEL_DIM = 1
 
 
 class TestDiceScoreOneClass:
-    metric = metrics.DiceScoreOneClass()
+    metric = metrics.DiceScore()
 
     def test_if_returns_1_for_perfect_fit(self):
         images = torch.ones(*BATCH_DIMS)


### PR DESCRIPTION
Adjusted the metrics and losses code to accept and correctly calculate values for multiple classes. The interface for input with just one class did not change at all (only the `dice_one_class` was renamed to just `dice` ), it will still return tensor with 0 dimensions (_kc torch_), and for multiclass it will return the array with metric value for each class. In the case of the dice loss, the values are summed up.

#35 